### PR TITLE
create Session module to wrap User and Topic

### DIFF
--- a/src/ActiveUser.elm
+++ b/src/ActiveUser.elm
@@ -5,6 +5,7 @@ module ActiveUser
     , updates
     , toMaybe
     , fromMaybe
+    , toUser
     ) where
 
 
@@ -76,3 +77,11 @@ fromMaybe maybeUser =
 
     Just user ->
       LoggedIn user
+
+toUser : ActiveUser -> User
+toUser maybeActive =
+  case maybeActive of
+    LoggedIn user ->
+      user
+    LoggedOut ->
+      User.empty

--- a/src/Login.elm
+++ b/src/Login.elm
@@ -53,13 +53,13 @@ type Action
 type alias ActionMap b = (Action -> b)
 
 
-type alias Context b =
-  { actions : ActionMap b
-  , complete : ActionMap b
+type alias Context a =
+  { next : ActionMap a
+  , complete : ActionMap a
   }
 
 
-update : Context b -> Action -> Model -> (Model, Effects Action, ActionMap b)
+update : Context a -> Action -> Model -> (Model, Effects a)
 update context message model =
   case message of
 
@@ -70,7 +70,6 @@ update context message model =
         "" ->
           ( { model | input = Empty }
           , Effects.none
-          , context.actions
           )
 
         raw ->
@@ -79,13 +78,11 @@ update context message model =
             Err _ ->
               ( model
               , Effects.none
-              , context.actions
               )
 
             Ok inputInt ->
               ( { model | input = UserId inputInt }
               , Effects.none
-              , context.actions
               )
 
     LoadUser ->
@@ -99,8 +96,7 @@ update context message model =
             Effects.none
       in
         ( model
-        , fx
-        , context.actions
+        , Effects.map context.next fx
         )
 
     ValidateUser maybeUser ->
@@ -112,7 +108,6 @@ update context message model =
             | message = "nope, please try again"
             , input = Empty }
           , Effects.none
-          , context.actions
           )
 
         Just user ->
@@ -120,12 +115,11 @@ update context message model =
           , NoOp
             |> Task.succeed
             |> Effects.task
-          , context.complete
+            |> Effects.map context.complete
           )
     NoOp ->
       ( model
       , Effects.none
-      , context.actions
       )
 
 

--- a/src/Login.elm
+++ b/src/Login.elm
@@ -50,12 +50,9 @@ type Action
   | NoOp
 
 
-type alias ActionMap b = (Action -> b)
-
-
 type alias Context a =
-  { next : ActionMap a
-  , complete : ActionMap a
+  { next : (Action -> a)
+  , complete : (Action -> a)
   }
 
 

--- a/src/Session.elm
+++ b/src/Session.elm
@@ -1,0 +1,189 @@
+module Session
+  ( Session
+  , init
+  , Action
+    ( SetUser
+    , ClearUser
+    , GoCompose
+    , GoConnect
+    )
+  , update
+  , view
+  ) where
+
+
+import User exposing (User)
+import Topic.Model as Topic exposing (Topic)
+import Opinion.Connector as Connector
+import Opinion.Composer as Composer
+
+
+import Html exposing (Html, div, h2, text)
+import Html.Attributes exposing (class)
+import Effects exposing (Effects)
+import Task
+
+
+type alias Session =
+  { user: User
+  , topic: Topic
+  , currentView: CurrentView
+  , composer: Composer.Model
+  , connector: Connector.Model
+  }
+
+
+type Action
+  -- exposed
+  = SetUser User
+  | ClearUser
+  | GoCompose Int
+  | GoConnect Int
+  -- private
+  | TopicMsg Topic.Action
+  | PropagateTopic
+  | ComposerMsg Composer.Action
+  | ConnectorMsg Connector.Action
+  | NoOp
+
+
+type CurrentView
+  = Compose
+  | Connect
+  | Empty
+
+
+init : Session
+init =
+  { user = User.empty
+  , topic = Topic.empty
+  , currentView = Empty
+  , composer = Composer.empty
+  , connector = Connector.empty
+  }
+
+
+update : Action -> Session -> (Session, Effects Action)
+update action session =
+  case action of
+    SetUser user ->
+      ( { session | user = user }
+      , Effects.none
+      )
+
+    ClearUser ->
+      ( { session | user = User.empty }
+      , Effects.none
+      )
+
+    -- GoCompose and GoConnect are exposed so that World can still control
+    -- routing.
+    -- Another approach might be to write an updateFromPath method for each
+    -- component, and to pass through a path object whenever the url changes
+    GoCompose topicId ->
+      let
+        (topicUpdate, topicUpdateFx) =
+          Topic.init topicId
+      in
+        ( { session | currentView = Compose }
+        , Effects.map TopicMsg topicUpdateFx
+        )
+
+    GoConnect topicId ->
+      let
+        (topicUpdate, topicUpdateFx) =
+          Topic.init topicId
+      in
+        ( { session | currentView = Connect }
+        , Effects.map TopicMsg topicUpdateFx
+        )
+
+    -- PRIVATE
+    TopicMsg topicAction ->
+      let
+        (topicUpdate, topicFx) =
+          Topic.update topicAction session.topic
+
+        -- If the state of the topic.isComplete has changed
+        -- from False -> True, then we need to update the child components.
+        --
+        -- When we load a connector/composer view, we first need to load the
+        -- Topic, then wait for the Effects to finish (since the effect is what
+        -- goes to the DB and retrieves the Topic).  Once the Topic is
+        -- retrieved we can then go ahead and load the composer/connector.
+        --
+        -- Maybe there's a better way to do this, but chaining effects is
+        -- difficult (impossible?), so we can't do Topic.update `andThen` ...
+        propagationFx =
+          if Topic.justCompleted session.topic topicUpdate then
+            Task.succeed PropagateTopic |> Effects.task
+          else
+            Effects.none
+
+      in
+        ( { session | topic = topicUpdate }
+        , Effects.batch
+          [ Effects.map TopicMsg topicFx
+          , propagationFx
+          ]
+        )
+
+    PropagateTopic ->
+      let
+        (composerUpdate, composerUpdateFx) =
+          Composer.init session.user session.topic
+        (connectorUpdate, connectorUpdateFx) =
+          Connector.init session.user session.topic
+      in
+        ( { session
+          | composer = composerUpdate
+          , connector = connectorUpdate
+          }
+        , Effects.batch
+          [ Effects.map ComposerMsg composerUpdateFx
+          , Effects.map ConnectorMsg connectorUpdateFx
+          ]
+        )
+
+    ComposerMsg composerAction ->
+      let
+        (update, updateFx) =
+          Composer.update composerAction session.composer
+      in
+        ( { session | composer = update }
+          , Effects.map ComposerMsg updateFx
+        )
+
+    ConnectorMsg connectAction ->
+      let (update, updateFx) =
+          Connector.update connectAction session.connector
+      in
+        ( { session | connector = update }
+        , Effects.map ConnectorMsg updateFx
+        )
+
+    NoOp ->
+      ( session, Effects.none )
+
+
+view : Signal.Address Action -> Session -> Html
+view address session =
+  let
+    header =
+      h2 [ class "topic-title" ] [ text session.topic.text ]
+    content =
+      case session.currentView of
+        Empty ->
+          div [] [ text "whoops, why we here?" ]
+        Connect ->
+          div
+            [ class "row" ]
+            (Connector.view (Signal.forwardTo address ConnectorMsg) session.connector)
+        Compose ->
+          Composer.view (Signal.forwardTo address ComposerMsg) session.composer
+  in
+    div
+      [ class "session" ]
+      [ header
+      , content
+      ]

--- a/src/World.elm
+++ b/src/World.elm
@@ -14,27 +14,22 @@ import Html.Events exposing (on, targetValue)
 import Task
 
 
-import Opinion.Connector as Connector
-import Opinion.Composer as Composer
-import User exposing (User)
+import Session exposing (Session)
 import Topic.Model exposing (Topic)
 import Topic.View
 import ActiveUser exposing (ActiveUser(LoggedIn, LoggedOut))
 import Login
 import Navigate
+
+
 import Routes exposing (Route)
-
-
 import TransitRouter
 import TransitStyle
 
 
 type alias Model = TransitRouter.WithRoute Routes.Route
-  { user : User
-  , topic : Topic
+  { session : Session
   , topics : List Topic
-  , connector : Connector.Model
-  , composer : Composer.Model
   , login : Login.Model
   }
 
@@ -42,10 +37,7 @@ type alias Model = TransitRouter.WithRoute Routes.Route
 type Action
   = LoginMsg Login.Action
   | LoginSuccess
-  | ConnectorLoad (Maybe Topic)
-  | ConnectorMsg Connector.Action
-  | ComposerLoad (Maybe Topic)
-  | ComposerMsg Composer.Action
+  | SessionMsg Session.Action
   | TopicsLoad (List Topic)
   | RouterAction (TransitRouter.Action Routes.Route)
   | LoadUserState ActiveUser
@@ -69,25 +61,21 @@ mountRoute prevRoute route model =
 
     Routes.Compose topicId ->
       ( model
-      , Topic.Model.get topicId
-          |> Task.toMaybe
-          |> Task.map ComposerLoad
-          |> Effects.task
+      -- since User and Topic live inside Session, we handle a topic update
+      -- by updating the Session
+      , updateSession <| Session.GoCompose topicId
       )
 
     Routes.Connect topicId ->
       ( model
-      , Topic.Model.get topicId -- Task Error Topic
-         |> Task.toMaybe -- Task Never (Maybe Topic)
-         |> Task.map ConnectorLoad
-         |> Effects.task
+      , updateSession <| Session.GoConnect topicId
       )
 
     -- map to [] if fail, since this will probably be the
     -- home page and we don't want to continually redirect
     Routes.Topics ->
       ( model
-      , Topic.Model.getAll
+      , Topic.Model.fetchAll
         |> Task.toMaybe
         |> Task.map (Maybe.withDefault [])
         |> Task.map TopicsLoad
@@ -109,27 +97,37 @@ routerConfig =
 
 init : String -> ActiveUser -> (Model, Effects Action)
 init path activeUser =
-  TransitRouter.init routerConfig path (initialModel activeUser)
+  let
+    (model, fx) =
+      TransitRouter.init routerConfig path initialModel
+
+  in
+    ( model
+    , Effects.batch
+      [ fx
+      , updateSession <| Session.SetUser (ActiveUser.toUser activeUser)])
 
 
-initialModel : ActiveUser -> Model
-initialModel activeUser =
+initialModel : Model
+initialModel =
   { transitRouter = TransitRouter.empty Routes.EmptyRoute
-  , user =
-      case activeUser of
-        LoggedIn user -> Debug.log "init logged in" user
-        LoggedOut -> Debug.log "init logged out" User.empty
-  , topic = Topic.Model.empty
   , topics = []
-  , connector = Connector.empty
-  , composer = Composer.empty
   , login = Login.init
+  , session = Session.init
   }
 
 
 update : Action -> Model -> (Model, Effects Action)
 update message model =
   case message of
+    SessionMsg sessionAction ->
+      let
+        (update, updateFx) =
+          Session.update sessionAction model.session
+      in
+        ( { model | session = update }
+        , Effects.map SessionMsg updateFx
+        )
 
     LoginMsg msg ->
       let
@@ -137,13 +135,10 @@ update message model =
           Login.update loginContext (Debug.log "Login msg" msg) model.login
       in
         ( { model | login = loginModel }
-        , Debug.log "Login msg fx" (Effects.map worldAction fx) )
+        , Effects.map worldAction fx )
 
     LoginSuccess ->
-        ( { model
-          | user = Debug.log "Success Update" (Login.getUser model.login)
-          , login = Login.init
-          }
+        ( model
         , Effects.batch
           [ goHome
           , Signal.send ActiveUser.save (Login.getUser model.login)
@@ -154,52 +149,6 @@ update message model =
 
     RouterAction routeAction ->
       TransitRouter.update routerConfig routeAction model
-
-    ConnectorLoad maybeTopic ->
-      case maybeTopic of
-        Nothing ->
-          ( model, goHome )
-
-        Just topic ->
-          let
-            (connector, fx) =
-              Connector.init model.user topic
-          in
-            ( { model | connector = connector }
-            , Effects.map ConnectorMsg fx
-            )
-
-    ConnectorMsg msg ->
-      let
-        (connector, fx) =
-          Connector.update msg model.connector
-      in
-        ( { model | connector = connector }
-        , Effects.map ConnectorMsg fx
-        )
-
-    ComposerLoad maybeTopic ->
-      case maybeTopic of
-        Nothing ->
-          ( model, goHome )
-
-        Just topic ->
-          let
-            (composer, fx) =
-              Composer.init model.user topic
-          in
-            ( { model | composer = composer }
-            , Effects.map ComposerMsg fx
-            )
-
-    ComposerMsg msg ->
-      let
-        (composer, fx) =
-          Composer.update msg model.composer
-      in
-        ( { model | composer = composer }
-        , Effects.map ComposerMsg fx
-        )
 
     TopicsLoad topics ->
       ( { model | topics = topics }
@@ -214,14 +163,18 @@ update message model =
       case activeUser of
 
         LoggedIn user ->
-          ( { model | user = Debug.log "Loaded user" user }
-          , Effects.none
+          ( model
+          , updateSession <| Session.SetUser user
           )
 
         LoggedOut ->
-          ( { model | user = Debug.log "Logging out user" User.empty }
-          , goHome
+          ( model
+          , Effects.batch
+            [ updateSession <| Session.ClearUser
+            , goHome
+            ]
           )
+
 
 loginContext : Login.Context Action
 loginContext =
@@ -230,14 +183,21 @@ loginContext =
     (\_ -> LoginSuccess)
 
 
+updateSession : Session.Action -> Effects Action
+updateSession sessionAction =
+  Task.succeed sessionAction
+    |> Task.map SessionMsg
+    |> Effects.task
+
+
 view : Signal.Address Action -> Model -> Html
 view address model =
 
   div [ class "world container" ]
-    [ Navigate.view model.user
+    [ Navigate.view model.session.user
     , div
       [ class "content" ]
-      [ case (TransitRouter.getRoute model) of
+      [ case TransitRouter.getRoute model of
 
         Routes.Topics ->
           div
@@ -249,17 +209,17 @@ view address model =
             [ Login.view (Signal.forwardTo address LoginMsg) model.login ]
 
         Routes.Connect _ ->
-          div
-            [ class "row" ]
-            (Connector.view (Signal.forwardTo address ConnectorMsg) model.connector)
+          Session.view (Signal.forwardTo address SessionMsg)
+            <| model.session
 
         Routes.Compose _ ->
-          Composer.view (Signal.forwardTo address ComposerMsg) model.composer
+          Session.view (Signal.forwardTo address SessionMsg) model.session
 
         Routes.EmptyRoute ->
           text ""
       ]
     ]
+
 
 goHome : Effects Action
 goHome =

--- a/src/World.elm
+++ b/src/World.elm
@@ -131,11 +131,12 @@ update message model =
 
     LoginMsg msg ->
       let
-        (loginModel, fx, worldAction) =
+        (loginModel, fx) =
           Login.update loginContext (Debug.log "Login msg" msg) model.login
       in
         ( { model | login = loginModel }
-        , Effects.map worldAction fx )
+        , fx -- the Login module uses the context to create a World.Action
+        )
 
     LoginSuccess ->
         ( model

--- a/src/World.elm
+++ b/src/World.elm
@@ -132,7 +132,10 @@ update message model =
     LoginMsg msg ->
       let
         (loginModel, fx) =
-          Login.update loginContext (Debug.log "Login msg" msg) model.login
+          Login.update
+            { next = LoginMsg , complete = (\_ -> LoginSuccess) }
+            (Debug.log "Login msg" msg)
+            model.login
       in
         ( { model | login = loginModel }
         , fx -- the Login module uses the context to create a World.Action
@@ -175,13 +178,6 @@ update message model =
             , goHome
             ]
           )
-
-
-loginContext : Login.Context Action
-loginContext =
-  Login.Context
-    LoginMsg
-    (\_ -> LoginSuccess)
 
 
 updateSession : Session.Action -> Effects Action

--- a/src/opinion/Composer.elm
+++ b/src/opinion/Composer.elm
@@ -26,14 +26,12 @@ import Topic.Model exposing (Topic)
 
 
 type alias Model =
-  { user : User
-  , topic : Topic
-  , opinion : Create.Model
+  { opinion : Create.Model
   }
 
 
 empty : Model
-empty = Model User.empty Topic.Model.empty Opinion.empty
+empty = Model Opinion.empty
 
 
 init : User -> Topic -> (Model, Effects Action)
@@ -42,7 +40,7 @@ init user topic =
     ( opinion, fx ) =
       Create.init user.id topic.id
   in
-    ( Model user topic opinion
+    ( Model opinion
     , Effects.map CreateMsg fx
     )
 

--- a/src/opinion/Connector.elm
+++ b/src/opinion/Connector.elm
@@ -1,6 +1,6 @@
 module Opinion.Connector
   ( Model
-  , Action(SetUser)
+  , Action
   , empty
   , init
   , view
@@ -27,27 +27,23 @@ type alias Paths = List Path.Model
 
 
 type alias Model =
-  { user : User
-  , topic : Topic
-  , rawPaths : Paths
+  { rawPaths : Paths
   , buckets : Dict.Dict Key Group.Model -- opinion paths bucketed by key
   }
 
 
 type Action
   = SetRaw Paths
-  | SetUser User
-  | SetTopic Topic
   | OpgMsg Key Group.Action
 
 
 empty : Model
-empty = Model User.empty Topic.Model.empty [] Dict.empty
+empty = Model [] Dict.empty
 
 
 init : User -> Topic -> (Model, Effects Action)
 init user topic =
-  ( Model user topic [] Dict.empty
+  ( Model [] Dict.empty
   , getConnectedOpinions topic user
   )
 
@@ -75,14 +71,6 @@ update message model =
               }
             , Effects.batch fxs
             )
-
-    SetTopic topic ->
-      ( { model | topic = topic }
-      , getConnectedOpinions topic model.user)
-
-    SetUser user ->
-      ( { model | user = user }
-      , getConnectedOpinions model.topic user)
 
     OpgMsg key subMsg ->
       case Dict.get key model.buckets of

--- a/src/opinion/Create.elm
+++ b/src/opinion/Create.elm
@@ -13,8 +13,6 @@ import Html exposing (Html, div, textarea, text)
 import Html.Attributes exposing (class, placeholder, value)
 import Html.Events exposing (on, targetValue)
 import Effects exposing (Effects)
-import Http
-import Task
 
 
 import Opinion.Credentials as Credentials
@@ -27,7 +25,8 @@ type alias Model = Opinion.Model
 init : Int -> Int -> (Model, Effects Action)
 init userId topicId =
   ( Opinion.empty
-  , getOpinion userId topicId
+  , Opinion.fetchByUserTopic userId topicId
+    |> Effects.map Init
   )
 
 
@@ -41,7 +40,7 @@ update : Action -> Model -> (Model, Effects Action)
 update message model =
   case message of
     Init retrieved ->
-      ( retrieved
+      ( Opinion.setExpanded retrieved
       , Effects.none
       )
 
@@ -53,27 +52,6 @@ update message model =
     CredentialsMsg msg ->
       ( { model | credentials = Credentials.update msg model.credentials}
       , Effects.none )
-
-
-getOpinion : Int -> Int -> Effects Action
-getOpinion userId topicId =
-  buildGetOpinionUrl userId topicId
-    |> Http.get Opinion.decoder
-    |> Task.toMaybe
-    |> Task.map Opinion.initExpanded
-    |> Task.map Init
-    |> Effects.task
-
-
-buildGetOpinionUrl : Int -> Int -> String
-buildGetOpinionUrl userId topicId =
-  String.concat
-    [ "http://localhost:3714/api/user/"
-    , toString userId
-    , "/topic/"
-    , toString topicId
-    , "/opinion"
-    ]
 
 
 viewCreator : Signal.Address Action -> Model -> Html

--- a/src/opinion/View.elm
+++ b/src/opinion/View.elm
@@ -11,8 +11,6 @@ import Effects exposing (Effects)
 import Html exposing (Html, div, text, p)
 import Html.Attributes exposing (class)
 import Markdown
-import Http
-import Task
 
 import Opinion.Model as Opinion
 import Opinion.Credentials as Credentials
@@ -24,7 +22,8 @@ type alias Model = Opinion.Model
 init : Int -> (Model, Effects Action)
 init oid =
   ( Opinion.empty
-  , getOpinion oid
+  , Opinion.fetch oid
+    |> Effects.map Init
   )
 
 
@@ -80,22 +79,4 @@ viewSnippet : Model -> Html
 viewSnippet model =
   div [ class "text snippet" ]
     [ p [] [ text model.snippet ]
-    ]
-
-
-getOpinion : Int -> Effects Action
-getOpinion opinionId =
-  buildGetOpinionUrl opinionId
-    |> Http.get Opinion.decoder
-    |> Task.toMaybe
-    |> Task.map Opinion.init
-    |> Task.map Init
-    |> Effects.task
-
-
-buildGetOpinionUrl : Int -> String
-buildGetOpinionUrl opinionId =
-  String.concat
-    [ "http://localhost:3714/api/opinion/"
-    , toString opinionId
     ]


### PR DESCRIPTION
I attempted to break up the World module.  It was large and handling multiple responsibilities.

This was more difficult than I originally anticipated.  At the heart of the difficulty, I think, is the way that a component updates itself, versus the way that a url change updates the entire app.

When the url changes state, there is a top-down propagation, in which each component must know which of its children depends on that state-change.

When a component updates its own state, the Effects Action propagates change in a bottom-up (and then top-down, and then bottom-up again) fashion.  But no component requires specific knowledge of the state of any other child or parent component.  

Anyway, after much teeth gnashing, this is what I came up with.  Session exposes a GoConnect and GoCompose which World can then use for routing.  

A further difficulty is what to do about components which require knowledge of _sibling_ components.  For example: Session.connector and Session.composer both rely on Session.topic.  The Session.topic load is async, but there is no easy way for a component to notify a sibling (or even a parent) of an Action completion.
